### PR TITLE
MAY omit the max_ack_delay if enough packets are in flight

### DIFF
--- a/draft-ietf-quic-ack-frequency.md
+++ b/draft-ietf-quic-ack-frequency.md
@@ -341,6 +341,10 @@ flight at any given time, this extension does not prohibit having more than one
 in flight. Generally, when using `max_ack_delay` for PTO computations, endpoints
 MUST use the maximum of the current value and all those in flight.
 
+When the number of in-flight ack-eliciting packets is larger than the
+ACK-Eliciting Threshold, implementations MAY choose to not include the peer's
+'max_ack_delay' in the probe timeout calculation.
+
 # Implementation Considerations {#implementation}
 
 There are tradeoffs inherent in a sender sending an ACK_FREQUENCY frame to the

--- a/draft-ietf-quic-ack-frequency.md
+++ b/draft-ietf-quic-ack-frequency.md
@@ -342,8 +342,11 @@ in flight. Generally, when using `max_ack_delay` for PTO computations, endpoints
 MUST use the maximum of the current value and all those in flight.
 
 When the number of in-flight ack-eliciting packets is larger than the
-ACK-Eliciting Threshold, implementations MAY choose to not include the peer's
-'max_ack_delay' in the probe timeout calculation.
+ACK-Eliciting Threshold, an endpoint can expect that the peer
+will not need to wait for its `max_ack_delay` period before
+sending an acknowledgement. In such cases, the endpoint MAY
+therefore exclude the peer's 'max_ack_delay' from its PTO
+calculation.
 
 # Implementation Considerations {#implementation}
 

--- a/draft-ietf-quic-ack-frequency.md
+++ b/draft-ietf-quic-ack-frequency.md
@@ -345,8 +345,8 @@ When the number of in-flight ack-eliciting packets is larger than the
 ACK-Eliciting Threshold, an endpoint can expect that the peer will not need to
 wait for its `max_ack_delay` period before sending an acknowledgement. In such
 cases, the endpoint MAY therefore exclude the peer's 'max_ack_delay' from its PTO
-calculation.  If `ignore_order` is enabled and packet(s) are lost, this
-optimization can cause premature PTOs, so requires extra caution.
+calculation. Note that this optimization requires some care in implementation, since
+it can cause premature PTOs under packet loss when `ignore_order` is enabled.
 
 # Implementation Considerations {#implementation}
 

--- a/draft-ietf-quic-ack-frequency.md
+++ b/draft-ietf-quic-ack-frequency.md
@@ -342,11 +342,11 @@ in flight. Generally, when using `max_ack_delay` for PTO computations, endpoints
 MUST use the maximum of the current value and all those in flight.
 
 When the number of in-flight ack-eliciting packets is larger than the
-ACK-Eliciting Threshold, an endpoint can expect that the peer
-will not need to wait for its `max_ack_delay` period before
-sending an acknowledgement. In such cases, the endpoint MAY
-therefore exclude the peer's 'max_ack_delay' from its PTO
-calculation.
+ACK-Eliciting Threshold, an endpoint can expect that the peer will not need to
+wait for its `max_ack_delay` period before sending an acknowledgement. In such
+cases, the endpoint MAY therefore exclude the peer's 'max_ack_delay' from its PTO
+calculation.  If `ignore_order` is enabled and packet(s) are lost, this
+optimization can cause premature PTOs, so requires extra caution.
 
 # Implementation Considerations {#implementation}
 


### PR DESCRIPTION
Fixes #37 by allowing implementations to not add max_ack_delay to the PTO calculation if enough ack-eliciting packets are in flight.