### PR TITLE
MUST NOT store min_ack_delay

### DIFF
--- a/draft-ietf-quic-ack-frequency.md
+++ b/draft-ietf-quic-ack-frequency.md
@@ -164,7 +164,7 @@ sends the min_ack_delay transport parameter or not.
 
 Endpoints MUST NOT remember the value of the min_ack_delay transport parameter
 they received. Due to this, ACK_FREQUENCY frames MUST NOT be sent in 0-RTT
-packets.
+packets, as per Section 7.4.1 of {{QUIC-TRANSPORT}}.
 
 This Transport Parameter is encoded as per Section 18 of {{QUIC-TRANSPORT}}.
 

--- a/draft-ietf-quic-ack-frequency.md
+++ b/draft-ietf-quic-ack-frequency.md
@@ -162,8 +162,9 @@ receiving ACK_FREQUENCY frames.  If an endpoint sends the transport parameter,
 the peer is allowed to send ACK_FREQUENCY frames independent of whether it also
 sends the min_ack_delay transport parameter or not.
 
-Endpoints MUST NOT remember the value of min_ack_delay transport parameter they received.
-Due to this, ACK_FREQUENCY frames MUST NOT be sent in 0-RTT packets.
+Endpoints MUST NOT remember the value of the min_ack_delay transport parameter
+they received. Due to this, ACK_FREQUENCY frames MUST NOT be sent in 0-RTT
+packets.
 
 This Transport Parameter is encoded as per Section 18 of {{QUIC-TRANSPORT}}.
 

--- a/draft-ietf-quic-ack-frequency.md
+++ b/draft-ietf-quic-ack-frequency.md
@@ -162,6 +162,11 @@ receiving ACK_FREQUENCY frames.  If an endpoint sends the transport parameter,
 the peer is allowed to send ACK_FREQUENCY frames independent of whether it also
 sends the min_ack_delay transport parameter or not.
 
+An endpoint MUST NOT send ACK_FREQUENCY frames until it has received the
+min_ack_delay transport parameter from the peer.  When clients use 0-RTT, they
+MUST NOT store the value of the server's min_ack_delay transport parameter.
+Due to this, ACK_FREQUENCY frames MUST NOT be sent in 0-RTT packets.
+
 This Transport Parameter is encoded as per Section 18 of {{QUIC-TRANSPORT}}.
 
 # ACK_FREQUENCY Frame

--- a/draft-ietf-quic-ack-frequency.md
+++ b/draft-ietf-quic-ack-frequency.md
@@ -163,7 +163,7 @@ the peer is allowed to send ACK_FREQUENCY frames independent of whether it also
 sends the min_ack_delay transport parameter or not.
 
 Endpoints MUST NOT remember the value of the min_ack_delay transport parameter
-they received. Consequently, ACK_FREQUENCY frames MUST NOT be sent in 0-RTT
+they received. Consequently, ACK_FREQUENCY frames cannot be sent in 0-RTT
 packets, as per Section 7.4.1 of {{QUIC-TRANSPORT}}.
 
 This Transport Parameter is encoded as per Section 18 of {{QUIC-TRANSPORT}}.

--- a/draft-ietf-quic-ack-frequency.md
+++ b/draft-ietf-quic-ack-frequency.md
@@ -163,7 +163,7 @@ the peer is allowed to send ACK_FREQUENCY frames independent of whether it also
 sends the min_ack_delay transport parameter or not.
 
 Endpoints MUST NOT remember the value of the min_ack_delay transport parameter
-they received. Due to this, ACK_FREQUENCY frames MUST NOT be sent in 0-RTT
+they received. Consequently, ACK_FREQUENCY frames MUST NOT be sent in 0-RTT
 packets, as per Section 7.4.1 of {{QUIC-TRANSPORT}}.
 
 This Transport Parameter is encoded as per Section 18 of {{QUIC-TRANSPORT}}.

--- a/draft-ietf-quic-ack-frequency.md
+++ b/draft-ietf-quic-ack-frequency.md
@@ -162,9 +162,7 @@ receiving ACK_FREQUENCY frames.  If an endpoint sends the transport parameter,
 the peer is allowed to send ACK_FREQUENCY frames independent of whether it also
 sends the min_ack_delay transport parameter or not.
 
-An endpoint MUST NOT send ACK_FREQUENCY frames until it has received the
-min_ack_delay transport parameter from the peer.  When clients use 0-RTT, they
-MUST NOT store the value of the server's min_ack_delay transport parameter.
+Endpoints MUST NOT remember the value of min_ack_delay transport parameter they received.
 Due to this, ACK_FREQUENCY frames MUST NOT be sent in 0-RTT packets.
 
 This Transport Parameter is encoded as per Section 18 of {{QUIC-TRANSPORT}}.


### PR DESCRIPTION
Closes #22 and #40

And by implication, cannot send ACK_FREQUENCY in 0-RTT packets.