### PR TITLE
ACK less frequently when CE marks are received

### DIFF
--- a/draft-ietf-quic-ack-frequency.md
+++ b/draft-ietf-quic-ack-frequency.md
@@ -323,10 +323,13 @@ acknowledgements.
 
 ## Expediting Congestion Signals {#congestion}
 
-As specified in Section 13.2.1 of {{QUIC-TRANSPORT}}, an endpoint SHOULD
-immediately acknowledge packets marked with the ECN Congestion Experienced (CE)
-codepoint in the IP header. Doing so reduces the peer's response time to
-congestion events.
+An endpoint SHOULD send an immediately acknowledgement when the more than
+max(2, Ack-Eliciting Threshold) packets marked with the ECN Congestion
+Experienced (CE) codepoint in the IP header are received. Doing so reduces the
+peer's response time to congestion events, while also reducing the ACK rate
+compared to Section 13.2.1 of {{QUIC-TRANSPORT}} when peers are using
+DCTCP {{?RFC8257}} or other congestion controllers that mark much more
+frequently than classic ECN {{?RFC3168}}.
 
 ## Batch Processing of Packets {#batch}
 


### PR DESCRIPTION
Per @bbriscoe's suggestion in #48, this PR changes the immediate ACK behavior to only send an immediate ACK when max(2, Ack-Eliciting Threshold) packets with CE marks have been received.

Fixes #48