### PR TITLE
Clarify an endpoint can send less ACKs when processing packets in a batch.

### DIFF
--- a/draft-ietf-quic-ack-frequency.md
+++ b/draft-ietf-quic-ack-frequency.md
@@ -347,7 +347,9 @@ enough packets to cause multiple acknowledgements to be sent.
 
 To avoid sending multiple acknowledgements in rapid succession, an endpoint MAY
 process all packets in a batch before determining whether a threshold has been
-met and an acknowledgement is to be sent in response.
+met and an acknowledgement is to be sent in response.  An endpoint MAY
+send less acknowledgements due to processing packets in a batch than
+it would if the packets were processed separately.
 
 
 # Computation of Probe Timeout Period

--- a/draft-ietf-quic-ack-frequency.md
+++ b/draft-ietf-quic-ack-frequency.md
@@ -348,8 +348,8 @@ enough packets to cause multiple acknowledgements to be sent.
 To avoid sending multiple acknowledgements in rapid succession, an endpoint MAY
 process all packets in a batch before determining whether a threshold has been
 met and an acknowledgement is to be sent in response.  An endpoint MAY
-send less acknowledgements due to processing packets in a batch than
-it would if the packets were processed separately.
+wait to process all available packets in a batch before sending an
+acknowledgement.
 
 
 # Computation of Probe Timeout Period


### PR DESCRIPTION
Fixes issue #30.