### PR TITLE
Update Congestion Control section

### DIFF
--- a/draft-ietf-quic-ack-frequency.md
+++ b/draft-ietf-quic-ack-frequency.md
@@ -421,7 +421,7 @@ estimated RTT, respectively.
 
 A congestion controller that is congestion window limited relies upon receiving
 acknowledgements to send additional data into the network.  An increase in
-acknowledgement delay increases the delay in sending data, which may reduce the
+acknowledgement delay increases the delay in sending data, which can reduce the
 achieved bandwidth.  Congestion window growth can also depend upon receiving
 acknowledgements, such as in slow start (Section 7.3.1 of {{QUIC-RECOVERY}}),
 so delaying acknowledgements delays the increase in congestion window.

--- a/draft-ietf-quic-ack-frequency.md
+++ b/draft-ietf-quic-ack-frequency.md
@@ -411,16 +411,15 @@ controllers.
 ## Congestion Control
 
 A sender needs to be responsive to notifications of congestion, such as
-a packet loss or an ECN CE marking. Therefore, {{Section 13.2.2 of QUIC-TRANSPORT}} 
-indicates "A receiver SHOULD send an ACK frame after receiving at least two ack-eliciting packets".
-This document overwrites this requirement by providing the sender with a way to signal its preferred
-ACK frequency to the receiver. To enable a sender to respond to potential
+a packet loss or an ECN CE marking. To enable a sender to respond to potential
 network congestion in a timely fashion, usually at least one acknowledgement
-per round-trip time (RTT) is needed if there are unacknowledged ack-eliciting packets in flight.
-A sender can accomplish this by sending an IMMEDIATE_ACK frame once per
-RTT. Similarly, setting the Ack-Eliciting Threshold to a lower value than the current congestion window or
-the Request Max Ack to less than the estimated RTT are two options to request at least one ACK frame per RTT.
-However, the congestion window particularly but also the RTT are dynamic and therefore might require frequent updates if the selected value are close to this limit.
+per round trip is needed if there are unacknowledged ack-eliciting packets
+in flight. A sender can accomplish this by setting the Ack-Eliciting Threshold
+to a value no larger than the current congestion window or the Request Max Ack
+Delay value to no more than the estimated round trip. A sender can typically
+accomplish this by sending an IMMEDIATE_ACK frame once per round trip, though
+if the packet containing an IMMEDIATE_ACK is lost, detection of that loss will be
+delayed by the reordering threshold or requested max ack delay.
 
 Note that it's possible the RTT is smaller than the receiver's timer granularity,
 as communicated via the 'min_ack_delay' transport parameter, preventing the

--- a/draft-ietf-quic-ack-frequency.md
+++ b/draft-ietf-quic-ack-frequency.md
@@ -408,7 +408,9 @@ network congestion in a timely fashion, usually at least one acknowledgement
 per round trip is needed if there are unacknowledged ack-eliciting packets
 in flight. A sender can accomplish this by setting the Ack-Eliciting Threshold
 to a value no larger than the current congestion window or the Request Max Ack
-Delay value to no more than the estimated round trip. Alternatively, a sender can
+Delay value to no more than the estimated round trip. Note that the congestion
+window particularly but also the RTT are dynamic and therefore might require frequent
+updates if the selected value are close to these limits. Alternatively, a sender can
 accomplish this by sending an IMMEDIATE_ACK frame once per round trip, though
 if the packet containing an IMMEDIATE_ACK is lost, detection of that loss will be
 delayed by the reordering threshold or requested max ack delay.

--- a/draft-ietf-quic-ack-frequency.md
+++ b/draft-ietf-quic-ack-frequency.md
@@ -431,10 +431,6 @@ achieved throughput.  Congestion window growth can also depend upon receiving
 acknowledgements, such as in slow start ({{Section 7.3.1 of QUIC-RECOVERY}}),
 so delaying acknowledgements can delay the increase in congestion window.
 
-Window-based congestion controllers, such as the one defined in {{QUIC-RECOVERY}},
-rely on receipt of acknowledgments to send additional data into the network,
-so performance is degraded if acknowledgments are delayed excessively.
-
 
 ## Burst Mitigation
 

--- a/draft-ietf-quic-ack-frequency.md
+++ b/draft-ietf-quic-ack-frequency.md
@@ -408,7 +408,7 @@ network congestion in a timely fashion, usually at least one acknowledgement
 per round trip is needed if there are unacknowledged ack-eliciting packets
 in flight. A sender can accomplish this by setting the Ack-Eliciting Threshold
 to a value no larger than the current congestion window or the Request Max Ack
-Delay value to no more than the estimated round trip. A sender can typically
+Delay value to no more than the estimated round trip. Alternatively, a sender can
 accomplish this by sending an IMMEDIATE_ACK frame once per round trip, though
 if the packet containing an IMMEDIATE_ACK is lost, detection of that loss will be
 delayed by the reordering threshold or requested max ack delay.

--- a/draft-ietf-quic-ack-frequency.md
+++ b/draft-ietf-quic-ack-frequency.md
@@ -424,11 +424,11 @@ acknowledgements to send additional data into the network.  An increase in
 acknowledgement delay increases the delay in sending data, which can reduce the
 achieved bandwidth.  Congestion window growth can also depend upon receiving
 acknowledgements, such as in slow start (Section 7.3.1 of {{QUIC-RECOVERY}}),
-so delaying acknowledgements delays the increase in congestion window.
+so delaying acknowledgements can delay the increase in congestion window.
 
 Window-based congestion controllers, such as the one defined in {{QUIC-RECOVERY}},
 rely on receipt of acknowledgments to send additional data into the network,
-and are degraded performance if acknowledgments are delayed excessively.
+so performance is degraded if acknowledgments are delayed excessively.
 
 
 ## Burst Mitigation

--- a/draft-ietf-quic-ack-frequency.md
+++ b/draft-ietf-quic-ack-frequency.md
@@ -409,11 +409,12 @@ per round trip is needed if there are unacknowledged ack-eliciting packets
 in flight. A sender can accomplish this by setting the Ack-Eliciting Threshold
 to a value no larger than the current congestion window or the Request Max Ack
 Delay value to no more than the estimated round trip. Note that the congestion
-window particularly but also the RTT are dynamic and therefore might require frequent
-updates if the selected value are close to these limits. Alternatively, a sender can
-accomplish this by sending an IMMEDIATE_ACK frame once per round trip, though
-if the packet containing an IMMEDIATE_ACK is lost, detection of that loss will be
-delayed by the reordering threshold or requested max ack delay.
+window particularly but also the RTT are dynamic and therefore might require
+frequent updates if the selected value are close to these limits. Alternatively,
+a sender can accomplish this by sending an IMMEDIATE_ACK frame once per
+round trip, though if the packet containing an IMMEDIATE_ACK is lost,
+detection of that loss will be delayed by the reordering threshold or requested
+max ack delay.
 
 Note that it is possible that the RTT is smaller than the receiver's timer granularity,
 as communicated via the 'min_ack_delay' transport parameter, preventing the

--- a/draft-ietf-quic-ack-frequency.md
+++ b/draft-ietf-quic-ack-frequency.md
@@ -422,7 +422,7 @@ estimated RTT, respectively.
 Note that it's possible the RTT is smaller than the receiver's timer granularity,
 as communicated via the 'min_ack_delay' transport parameter, preventing the
 receiver from sending an acknowledgment every RTT in time.  In these cases,
-'Ignore Order' can be harmful, because it delays fast loss detection.
+'Reordering Threshold' can be harmful, because it delays fast loss detection.
 
 A congestion controller that is congestion window limited relies upon receiving
 acknowledgements to send additional data into the network.  An increase in

--- a/draft-ietf-quic-ack-frequency.md
+++ b/draft-ietf-quic-ack-frequency.md
@@ -411,18 +411,25 @@ controllers.
 ## Congestion Control
 
 A sender needs to be responsive to notifications of congestion, such as
-a packet loss or an ECN CE marking. Also, window-based congestion controllers
-that strictly adhere to packet conservation, such as the one defined in
-{{QUIC-RECOVERY}}, rely on receipt of acknowledgments to send additional data into
-the network, and will suffer degraded performance if acknowledgments are delayed
-excessively.
+a packet loss or an ECN CE marking.  To enable a sender to respond to potential
+network congestion, a sender SHOULD cause a receiver to send an acknowledgement
+at least once per RTT if there are unacknowledged ack-eliciting packets in flight.
+A sender can accomplish this by sending an IMMEDIATE_ACK frame once per
+round-trip time (RTT), or it can set the Ack-Eliciting Threshold and
+Request Max Ack Delay values to be no more than a congestion window and an
+estimated RTT, respectively.
 
-To enable a sender to respond to potential network congestion, a sender SHOULD
-cause a receiver to send an acknowledgement at least once per RTT if there are
-unacknowledged ack-eliciting packets in flight. A sender can accomplish this by
-sending an IMMEDIATE_ACK frame once per round-trip time (RTT), or it can set the
-Ack-Eliciting Threshold and Request Max Ack Delay values to be no more than a
-congestion window and an estimated RTT, respectively.
+A congestion controller that is congestion window limited relies upon receiving
+acknowledgements to send additional data into the network.  An increase in
+acknowledgement delay increases the delay in sending data, which may reduce the
+achieved bandwidth.  Congestion window growth can also depend upon receiving
+acknowledgements, such as in slow start (Section 7.3.1 of {{QUIC-RECOVERY}}),
+so delaying acknowledgements delays the increase in congestion window.
+
+Window-based congestion controllers, such as the one defined in {{QUIC-RECOVERY}},
+rely on receipt of acknowledgments to send additional data into the network,
+and are degraded performance if acknowledgments are delayed excessively.
+
 
 ## Burst Mitigation
 

--- a/draft-ietf-quic-ack-frequency.md
+++ b/draft-ietf-quic-ack-frequency.md
@@ -416,7 +416,8 @@ delayed by the reordering threshold or requested max ack delay.
 Note that it's possible the RTT is smaller than the receiver's timer granularity,
 as communicated via the 'min_ack_delay' transport parameter, preventing the
 receiver from sending an acknowledgment every RTT in time.  In these cases,
-'Reordering Threshold' can be harmful, because it delays fast loss detection.
+Reordering Threshold values other than 1 can be harmful, because it delays fast
+loss detection.
 
 A congestion controller that is congestion window limited relies upon receiving
 acknowledgements to send additional data into the network.  An increase in

--- a/draft-ietf-quic-ack-frequency.md
+++ b/draft-ietf-quic-ack-frequency.md
@@ -427,7 +427,7 @@ receiver from sending an acknowledgment every RTT in time.  In these cases,
 A congestion controller that is congestion window limited relies upon receiving
 acknowledgements to send additional data into the network.  An increase in
 acknowledgement delay increases the delay in sending data, which can reduce the
-achieved bandwidth.  Congestion window growth can also depend upon receiving
+achieved throughput.  Congestion window growth can also depend upon receiving
 acknowledgements, such as in slow start ({{Section 7.3.1 of QUIC-RECOVERY}}),
 so delaying acknowledgements can delay the increase in congestion window.
 

--- a/draft-ietf-quic-ack-frequency.md
+++ b/draft-ietf-quic-ack-frequency.md
@@ -419,6 +419,11 @@ round-trip time (RTT), or it can set the Ack-Eliciting Threshold and
 Request Max Ack Delay values to be no more than a congestion window and an
 estimated RTT, respectively.
 
+Note that it's possible the RTT is smaller than the receiver's timer granularity,
+as communicated via the 'min_ack_delay' transport parameter, preventing the
+receiver from sending an acknowledgment every RTT in time.  In these cases,
+'Ignore Order' can be harmful, because it delays fast loss detection.
+
 A congestion controller that is congestion window limited relies upon receiving
 acknowledgements to send additional data into the network.  An increase in
 acknowledgement delay increases the delay in sending data, which can reduce the

--- a/draft-ietf-quic-ack-frequency.md
+++ b/draft-ietf-quic-ack-frequency.md
@@ -411,13 +411,16 @@ controllers.
 ## Congestion Control
 
 A sender needs to be responsive to notifications of congestion, such as
-a packet loss or an ECN CE marking.  To enable a sender to respond to potential
-network congestion, a sender SHOULD cause a receiver to send an acknowledgement
-at least once per RTT if there are unacknowledged ack-eliciting packets in flight.
+a packet loss or an ECN CE marking. Therefore, {{Section 13.2.2 of QUIC-TRANSPORT}} 
+indicates "A receiver SHOULD send an ACK frame after receiving at least two ack-eliciting packets".
+This document overwrites this requirement by providing the sender with a way to signal its preferred
+ACK frequency to the receiver. To enable a sender to respond to potential
+network congestion in a timely fashion, usually at least one acknowledgement
+per round-trip time (RTT) is needed if there are unacknowledged ack-eliciting packets in flight.
 A sender can accomplish this by sending an IMMEDIATE_ACK frame once per
-round-trip time (RTT), or it can set the Ack-Eliciting Threshold and
-Request Max Ack Delay values to be no more than a congestion window and an
-estimated RTT, respectively.
+RTT. Similarly, setting the Ack-Eliciting Threshold to a lower value than the current congestion window or
+the Request Max Ack to less than the estimated RTT are two options to request at least one ACK frame per RTT.
+However, the congestion window particularly but also the RTT are dynamic and therefore might require frequent updates if the selected value are close to this limit.
 
 Note that it's possible the RTT is smaller than the receiver's timer granularity,
 as communicated via the 'min_ack_delay' transport parameter, preventing the

--- a/draft-ietf-quic-ack-frequency.md
+++ b/draft-ietf-quic-ack-frequency.md
@@ -428,8 +428,9 @@ A congestion controller that is congestion window limited relies upon receiving
 acknowledgements to send additional data into the network.  An increase in
 acknowledgement delay increases the delay in sending data, which can reduce the
 achieved throughput.  Congestion window growth can also depend upon receiving
-acknowledgements, such as in slow start ({{Section 7.3.1 of QUIC-RECOVERY}}),
-so delaying acknowledgements can delay the increase in congestion window.
+acknowledgements. This can be particularly significant in slow start ({{Section 7.3.1 of QUIC-RECOVERY}}),
+as delaying acknowledgements can delay the increase in congestion window and can
+create larger packet bursts.
 
 
 ## Burst Mitigation

--- a/draft-ietf-quic-ack-frequency.md
+++ b/draft-ietf-quic-ack-frequency.md
@@ -423,7 +423,7 @@ A congestion controller that is congestion window limited relies upon receiving
 acknowledgements to send additional data into the network.  An increase in
 acknowledgement delay increases the delay in sending data, which can reduce the
 achieved bandwidth.  Congestion window growth can also depend upon receiving
-acknowledgements, such as in slow start (Section 7.3.1 of {{QUIC-RECOVERY}}),
+acknowledgements, such as in slow start ({{Section 7.3.1 of QUIC-RECOVERY}}),
 so delaying acknowledgements can delay the increase in congestion window.
 
 Window-based congestion controllers, such as the one defined in {{QUIC-RECOVERY}},

--- a/draft-ietf-quic-ack-frequency.md
+++ b/draft-ietf-quic-ack-frequency.md
@@ -428,9 +428,9 @@ A congestion controller that is congestion window limited relies upon receiving
 acknowledgements to send additional data into the network.  An increase in
 acknowledgement delay increases the delay in sending data, which can reduce the
 achieved throughput.  Congestion window growth can also depend upon receiving
-acknowledgements. This can be particularly significant in slow start ({{Section 7.3.1 of QUIC-RECOVERY}}),
-as delaying acknowledgements can delay the increase in congestion window and can
-create larger packet bursts.
+acknowledgements. This can be particularly significant in slow start
+({{Section 7.3.1 of QUIC-RECOVERY}}), when delaying acknowledgements can delay
+the increase in congestion window and can create larger packet bursts.
 
 
 ## Burst Mitigation

--- a/draft-ietf-quic-ack-frequency.md
+++ b/draft-ietf-quic-ack-frequency.md
@@ -413,7 +413,7 @@ accomplish this by sending an IMMEDIATE_ACK frame once per round trip, though
 if the packet containing an IMMEDIATE_ACK is lost, detection of that loss will be
 delayed by the reordering threshold or requested max ack delay.
 
-Note that it's possible the RTT is smaller than the receiver's timer granularity,
+Note that it is possible that the RTT is smaller than the receiver's timer granularity,
 as communicated via the 'min_ack_delay' transport parameter, preventing the
 receiver from sending an acknowledgment every RTT in time.  In these cases,
 Reordering Threshold values other than 1 can be harmful, because it delays fast


### PR DESCRIPTION
Fixes #106

Removes the normative SHOULD from: "a sender SHOULD cause a receiver to send an acknowledgement at least once per RTT if there are unacknowledged ack-eliciting packets in flight". It may be added back in some form, see issue #147 