### PR TITLE
Add normative text for 'Ignore CE'

### DIFF
--- a/draft-ietf-quic-ack-frequency.md
+++ b/draft-ietf-quic-ack-frequency.md
@@ -372,9 +372,9 @@ still sends an immediate acknowledgement if it would have for a non CE marked
 packet.  If an immediate acknowledgement is not send, the CE marks are reported
 in the next acknowledgement.
 
-The Ignore-CE bit SHOULD NOT be set if ECT(1) is negotiated with DCTCP
-{{?RFC8257}} or L4S, because it delays the congestion controller's ability to
-quickly respond to congestion.
+The Ignore-CE bit SHOULD NOT be set if the sender sets ECT(1) in its outgoing
+packets, such as with L4S, because it delays the congestion controller's ability
+to quickly respond to congestion.
 
 ## Batch Processing of Packets {#batch}
 

--- a/draft-ietf-quic-ack-frequency.md
+++ b/draft-ietf-quic-ack-frequency.md
@@ -365,6 +365,10 @@ reducing the ACK rate compared to {{Section 13.2.1 of QUIC-TRANSPORT}} during
 extreme congestion or when peers are using DCTCP {{?RFC8257}} or other
 congestion controllers that mark more frequently than classic ECN {{?RFC3168}}.
 
+If the most recent ACK_FREQUENCY frame an endpoint has received from the peer
+has an `Ignore CE` value of `true` (0x01), the endpoint SHOULD NOT send an
+immediate acknowledgement when receiving a CE marked packet.
+
 ## Batch Processing of Packets {#batch}
 
 For performance reasons, an endpoint can receive incoming packets from the

--- a/draft-ietf-quic-ack-frequency.md
+++ b/draft-ietf-quic-ack-frequency.md
@@ -366,8 +366,10 @@ extreme congestion or when peers are using DCTCP {{?RFC8257}} or other
 congestion controllers that mark more frequently than classic ECN {{?RFC3168}}.
 
 If the most recent ACK_FREQUENCY frame an endpoint has received from the peer
-has an `Ignore CE` value of `true` (0x01), the endpoint SHOULD NOT send an
-immediate acknowledgement when receiving a CE marked packet.
+has an `Ignore CE` value of `true` (0x01), receipt of a CE marked packet
+SHOULD NOT cause an endpoint to send an immediate acknowledgement.  The endpoint
+still sends an immediate acknowledgement if it would have for a non CE marked
+packet.  Otherwise, the CE marks are reported in the next acknowledgement.
 
 ## Batch Processing of Packets {#batch}
 

--- a/draft-ietf-quic-ack-frequency.md
+++ b/draft-ietf-quic-ack-frequency.md
@@ -371,6 +371,10 @@ SHOULD NOT cause an endpoint to send an immediate acknowledgement.  The endpoint
 still sends an immediate acknowledgement if it would have for a non CE marked
 packet.  Otherwise, the CE marks are reported in the next acknowledgement.
 
+The Ignore-CE bit SHOULD NOT be set if ECT(1) is negotiated with DCTCP
+{{?RFC8257}} or L4S, because it delays the congestion controller's ability to
+quickly respond to congestion.
+
 ## Batch Processing of Packets {#batch}
 
 For performance reasons, an endpoint can receive incoming packets from the

--- a/draft-ietf-quic-ack-frequency.md
+++ b/draft-ietf-quic-ack-frequency.md
@@ -369,7 +369,7 @@ If the most recent ACK_FREQUENCY frame an endpoint has received from the peer
 has an `Ignore CE` value of `true` (0x01), receipt of a CE marked packet
 SHOULD NOT cause an endpoint to send an immediate acknowledgement.  The endpoint
 still sends an immediate acknowledgement if it would have for a non CE marked
-packet.  If an immediate acknowledgement is not send, the CE marks are reported
+packet.  If an immediate acknowledgement is not sent, the CE marks are reported
 in the next acknowledgement.
 
 The Ignore-CE bit SHOULD NOT be set if the sender sets ECT(1) in its outgoing

--- a/draft-ietf-quic-ack-frequency.md
+++ b/draft-ietf-quic-ack-frequency.md
@@ -369,7 +369,8 @@ If the most recent ACK_FREQUENCY frame an endpoint has received from the peer
 has an `Ignore CE` value of `true` (0x01), receipt of a CE marked packet
 SHOULD NOT cause an endpoint to send an immediate acknowledgement.  The endpoint
 still sends an immediate acknowledgement if it would have for a non CE marked
-packet.  Otherwise, the CE marks are reported in the next acknowledgement.
+packet.  If an immediate acknowledgement is not send, the CE marks are reported
+in the next acknowledgement.
 
 The Ignore-CE bit SHOULD NOT be set if ECT(1) is negotiated with DCTCP
 {{?RFC8257}} or L4S, because it delays the congestion controller's ability to


### PR DESCRIPTION
We have normative text for Ignore Order, but none for Ignore CE.

SHOULD NOT use with ECN(1) marking per L4S or DCTCP.

Fixes #107 
Fixes #109