### PR TITLE
Context for asymmetric paths

### DIFF
--- a/draft-ietf-quic-ack-frequency.md
+++ b/draft-ietf-quic-ack-frequency.md
@@ -60,6 +60,24 @@ normative:
         org: Google
         role: editor
 
+imformative:
+
+  Cus22:
+    title: "Reducing the acknowledgement frequency in IETF QUIC"
+    date: 2022-10
+    seriesinfo:
+      DOI: 10.1002/sat.1466
+      name: IJSCN    
+    author:
+      -
+        name: A. Custura
+        org: University of Aberdeen
+      -
+        name: R. Secchi
+        org: University of Aberdeen
+      -
+        name: G. Fairhurst
+        org: University of Aberdeen
 
 --- abstract
 
@@ -119,15 +137,20 @@ endpoint performance in the following ways:
 - Similarly, receiving and processing UDP packets can also be CPU intensive, and
   reducing acknowledgement frequency reduces this cost at a data sender.
 
-- For severely asymmetric link technologies, such as DOCSIS, LTE, and satellite
-  links, connection throughput in the forward path can become constrained
-  when the reverse path is filled by acknowledgment packets. When traversing
-  such links, reducing the number of acknowledgments can achieve higher
-  connection throughput.
+- For some network technologies, such as DOCSIS, LTE, and satellite,
+link transmission in the forward direction can depend on transmission in the return
+direction. This occurs when both directions share capacity from a common link
+resource pool, or when significantly more resource is required
+to send in one direction that the other, or because design decisions result in
+much more capacity being available in one direction {{?RFC3449}}. When traversing
+this type of path, reducing the number of acknowledgments can achieve higher
+connection throughput, lower the impact on other flows or optimise the
+overall use of transmission resources {{Cus22}}.
 
 - The rate of acknowledgment packets can impact link efficiency, including
-  transmission opportunities or battery life.
-
+  transmission opportunities or battery life. In some cases, 
+consumption of link resources can also impact other users that share the link or 
+are allocated capacity from the same resource pool.
 
 As discussed in {{implementation}} however, there can be undesirable consequences
 to congestion control and loss recovery if a receiver uniltaerally reduces the

--- a/draft-ietf-quic-ack-frequency.md
+++ b/draft-ietf-quic-ack-frequency.md
@@ -67,7 +67,7 @@ imformative:
     date: 2022-10
     seriesinfo:
       DOI: 10.1002/sat.1466
-      name: IJSCN    
+      name: IJSCN
     author:
       -
         name: A. Custura
@@ -148,8 +148,8 @@ connection throughput, lower the impact on other flows or optimise the
 overall use of transmission resources {{Cus22}}.
 
 - The rate of acknowledgment packets can impact link efficiency, including
-  transmission opportunities or battery life. In some cases, 
-consumption of link resources can also impact other users that share the link or 
+  transmission opportunities or battery life. In some cases,
+consumption of link resources can also impact other users that share the link or
 are allocated capacity from the same resource pool.
 
 As discussed in {{implementation}} however, there can be undesirable consequences

--- a/draft-ietf-quic-ack-frequency.md
+++ b/draft-ietf-quic-ack-frequency.md
@@ -60,7 +60,7 @@ normative:
         org: Google
         role: editor
 
-imformative:
+informative:
 
   Cus22:
     title: "Reducing the acknowledgement frequency in IETF QUIC"


### PR DESCRIPTION
Pull request comes from Gorry Fairhurst via me, as promised at IETF 115.

The current text is an excellent start but does not sufficiently address the range of scenarios and reasons why the ACK Frequency Draft is important for networks with different characteristics beyond just asymmetric capacity. We propose to enhance it by adding context, which if merged would address issue https://github.com/quicwg/ack-frequency/issues/53 without having to write an example in the draft.

