### PR TITLE
Explain how to use the Reordering threshold

### DIFF
--- a/draft-ietf-quic-ack-frequency.md
+++ b/draft-ietf-quic-ack-frequency.md
@@ -343,8 +343,27 @@ the endpoint immediately acknowledges any subsequent packets that
 are received out of order, as specified in {{Section 13.2 of QUIC-TRANSPORT}}.
 An endpoint, that receives an ACK_FREQUENCY frame with a Reordering
 Threshold value other than 0x00, MUST immediately send an ACK frame
-when the packet number of largest unacknowledged packet since
+when the offset of the largest received packet number since
 the last detected reordering event exceeds the Reordering Threshold.
+
+More correctly, this means if a gap in the packet number is
+detected, one additional ACK frame will be sent if the difference between the largest received packet number and the packet number
+of the last in-order packet number is larger than the Reordering Threshold for the first time
+(largest_unacknowledged - largest_inorder > Reordering Threshold).
+Therefore the Reordering Threshold causes an ACK to be send earlier than it would
+otherwise be sent based on the Ack-Eliciting Threshold and max_ack_delay.
+This ensures that an acknowledgement is sent at the earliest point of time
+when the peer is able to declare missing packets as lost. This can reduce the time to
+detect loss and therefore improve the performance of loss recovery.
+
+If a potential reordering events happens, which means a gap in the packet number is
+detected, an additional ack will be sent if no ack has been sent based on the other
+conditions since the reordering event (largest_acknowledged_sent <= largest_inorder)
+and the offset between the largest unacknowledged packet number and the packet number
+of the last in-order packet number exceeds the Reordering Threshold
+(largest_unacknowledged - largest_inorder > Reordering Threshold).
+Note that this means the Reordering Threshold is only effective if it is smaller
+than the Ack-Eliciting Threshold.
 
 If the most recent ACK_FREQUENCY frame received from the peer has a `Reordering
 Threshold` value of 0x00, the endpoint does not make this exception. That

--- a/draft-ietf-quic-ack-frequency.md
+++ b/draft-ietf-quic-ack-frequency.md
@@ -346,7 +346,7 @@ Threshold value other than 0x00, MUST immediately send an ACK frame
 when the offset of the largest received packet number since
 the last detected reordering event exceeds the Reordering Threshold.
 
-More correctly, this means if a gap in the packet number is
+More concretely, this means if a gap in the packet number is
 detected, one additional ACK frame will be sent if the difference between the largest received packet number and the packet number
 of the last in-order packet number is larger than the Reordering Threshold for the first time
 (largest_unacknowledged - largest_inorder > Reordering Threshold).


### PR DESCRIPTION
fixes #140

Previous attempts to describe the use of the Reordering threshold, tried to specify a continuous range where this condition would be true (e.g. if gaps are in the  range [Last_Acked, Last_Received - Reorder_Threshold]. This means that you would keep sending ACKs for each packet as long as the re-ordering/loss event is on-going. I don't think this should be the intention. Instead my understanding would be that you send one additional ack and then go back to your usual ack strategy. This is what this PR tries to explain.

This is also inline with the behaviour in RFC9000:
> when the packet has a packet number larger than the highest-numbered ack-eliciting packet that has been received and there are missing packets between that packet and this packet.

This mean in RFC9000 you send an ACK when a gap is detected but as soon as you have send the ACK, the highest-numbered ack-eliciting packet is after the gap and you don't send any additional ACKs for this gap.

I think any other behaviour would actually be problematic as the sender can send packets with gaps in the packet number space without a loss, which means the gap would also never be closed.