### PR TITLE
Alternative PR to add MUSTs in multiple-frame section

### DIFF
--- a/draft-ietf-quic-ack-frequency.md
+++ b/draft-ietf-quic-ack-frequency.md
@@ -205,7 +205,7 @@ Sequence Number:
 
 : A variable-length integer representing the sequence number assigned to the
   ACK_FREQUENCY frame by the sender to allow receivers to ignore obsolete
-  frames, see {{multiple-frames}}.
+  frames.
 
 Ack-Eliciting Threshold:
 
@@ -291,7 +291,7 @@ Prior to receiving an ACK_FREQUENCY frame, endpoints send acknowledgements as
 specified in {{Section 13.2.1 of QUIC-TRANSPORT}}.
 
 On receiving an ACK_FREQUENCY frame and updating its recorded `max_ack_delay`
-and `Ack-Eliciting Threshold` values ({{multiple-frames}}), the endpoint MUST send an
+and `Ack-Eliciting Threshold` values ({{ack-frequency-frame}}), the endpoint MUST send an
 acknowledgement when one of the following conditions are met:
 
 - Since the last acknowledgement was sent, the number of received ack-eliciting

--- a/draft-ietf-quic-ack-frequency.md
+++ b/draft-ietf-quic-ack-frequency.md
@@ -244,11 +244,11 @@ as the receiver will ignore duplicate or out-of-order ACK_FREQUENCY frames
 based on the Sequence Number.
 
 An endpoint MAY send multiple ACK_FREQUENCY frames with different values within a
-connection. The Sequence Number field allows reordered ACK_FREQUENCY frames
-to be received and processed in the intended order, see {{Section 13.3 of QUIC-TRANSPORT}}. A sending
-endpoint MUST send monotonically increasing values in the Sequence Number field.
-A receiving endpoint MUST ignore a received ACK_FREQUENCY frame if the Sequence Number
-value is not greater than the largest seen thus far.
+connection. A sending endpoint MUST send monotonically increasing values in the
+Sequence Number field, since this field allows reordered ACK_FREQUENCY
+frames to be received out of order. A receiving endpoint processes only the latest
+information it receives and MUST ignore a received ACK_FREQUENCY frame if the
+Sequence Number value is not greater than the largest processed thus far.
 
 An endpoint will have committed a `max_ack_delay` value to the peer, which
 specifies the maximum amount of time by which the endpoint will delay sending

--- a/draft-ietf-quic-ack-frequency.md
+++ b/draft-ietf-quic-ack-frequency.md
@@ -244,8 +244,8 @@ as the receiver will ignore duplicate or out-of-order ACK_FREQUENCY frames
 based on the Sequence Number.
 
 An endpoint MAY send multiple ACK_FREQUENCY frames with different values within a
-connection. However, the Sequence Number field allows reordered ACK_FREQUENCY frames
-to be received and processed, see {{Section 13.3 of QUIC-TRANSPORT}}. A sending
+connection. The Sequence Number field allows reordered ACK_FREQUENCY frames
+to be received and processed in the intended order, see {{Section 13.3 of QUIC-TRANSPORT}}. A sending
 endpoint MUST send monotonically increasing values in the Sequence Number field.
 A receiving endpoint MUST ignore a received ACK_FREQUENCY frame if the Sequence Number
 value is not greater than the largest seen thus far.

--- a/draft-ietf-quic-ack-frequency.md
+++ b/draft-ietf-quic-ack-frequency.md
@@ -243,27 +243,18 @@ forbidden to retransmit the lost frame (see Section 13.3 of {{QUIC-TRANSPORT}),
 as the receiver will ignore duplicate or out-of-order ACK_FREQUENCY frames
 based on the Sequence Number.
 
-An endpoint MAY send ACK_FREQUENCY frames multiple times during a connection and
-with different values.
+An endpoint MAY send multiple ACK_FREQUENCY frames with different values within a
+connection. However, the Sequence Number field allows reordered ACK_FREQUENCY frames
+to be received and processed, see {{Section 13.3 of QUIC-TRANSPORT}}. A sending
+endpoint MUST send monotonically increasing values in the Sequence Number field.
+A receiving endpoint MUST ignore a received ACK_FREQUENCY frame if the Sequence Number
+value is not greater than the largest seen thus far.
 
 An endpoint will have committed a `max_ack_delay` value to the peer, which
 specifies the maximum amount of time by which the endpoint will delay sending
 acknowledgments. When the endpoint receives an ACK_FREQUENCY frame, it MUST
 update this maximum time to the value proposed by the peer in the Request Max
 Ack Delay field.
-
-
-# Multiple ACK_FREQUENCY Frames {#multiple-frames}
-
-An endpoint can send multiple ACK_FREQUENCY frames, and each one of them can
-have different values in all fields. An endpoint MUST use a sequence number of 0
-for the first ACK_FREQUENCY frame it constructs and sends, and a strictly
-increasing value thereafter.  The sequence number allows reordered ACK_FREQUENCY frames to be received and processed, see {{Section 13.3 of QUIC-TRANSPORT}}.
-
-The endpoint MUST ignore the frame if the Sequence Number is not larger than the last processed Sequence Number.
-If the Sequence number is larger, the endpoint MUST update its state with values received
-in this frame, including the processed largest Sequence Number.
-
 
 # IMMEDIATE_ACK Frame {#immediate-ack-frame}
 

--- a/draft-ietf-quic-ack-frequency.md
+++ b/draft-ietf-quic-ack-frequency.md
@@ -245,10 +245,9 @@ based on the Sequence Number.
 
 An endpoint MAY send multiple ACK_FREQUENCY frames with different values within a
 connection. A sending endpoint MUST send monotonically increasing values in the
-Sequence Number field, since this field allows reordered ACK_FREQUENCY
-frames to be received out of order. A receiving endpoint processes only the latest
-information it receives and MUST ignore a received ACK_FREQUENCY frame if the
-Sequence Number value is not greater than the largest processed thus far.
+Sequence Number field, since this field allows ACK_FREQUENCY frames to be received
+out of order. A receiving endpoint MUST ignore a received ACK_FREQUENCY frame if the
+Sequence Number value in the frame is not greater than the largest processed thus far.
 
 An endpoint will have committed a `max_ack_delay` value to the peer, which
 specifies the maximum amount of time by which the endpoint will delay sending

--- a/draft-ietf-quic-ack-frequency.md
+++ b/draft-ietf-quic-ack-frequency.md
@@ -258,12 +258,10 @@ Ack Delay field.
 An endpoint can send multiple ACK_FREQUENCY frames, and each one of them can
 have different values in all fields. An endpoint MUST use a sequence number of 0
 for the first ACK_FREQUENCY frame it constructs and sends, and a strictly
-increasing value thereafter.
+increasing value thereafter.  The sequence number allows reordered ACK_FREQUENCY frames to be received and processed, see {{Section 13.3 of QUIC-TRANSPORT}}.
 
-An endpoint might receive an ACK_FREQUENCY frame out of order
-(see {{Section 13.3 of QUIC-TRANSPORT}}).
-The endpoint MUST ignore the frame if the Sequence Number is smaller than the last processed Sequence Number.
-Otherwise, the endpoint MUST update its state with values received
+The endpoint MUST ignore the frame if the Sequence Number is not larger than the last processed Sequence Number.
+If the Sequence number is larger, the endpoint MUST update its state with values received
 in this frame, including the processed largest Sequence Number.
 
 

--- a/draft-ietf-quic-ack-frequency.md
+++ b/draft-ietf-quic-ack-frequency.md
@@ -262,7 +262,7 @@ increasing value thereafter.
 
 An endpoint might receive an ACK_FREQUENCY frame out of order 
 (see {{Section 13.3 of QUIC-TRANSPORT}}). 
-The enpoint MUST ignore the frame if the Sequence Number is smaller than the last processed Sequence Number.
+The endpoint MUST ignore the frame if the Sequence Number is smaller than the last processed Sequence Number.
 Otherwise, the endpoint MUST update its state with values received
 in this frame, including the processed largest Sequence Number.
 

--- a/draft-ietf-quic-ack-frequency.md
+++ b/draft-ietf-quic-ack-frequency.md
@@ -243,7 +243,7 @@ forbidden to retransmit the lost frame (see Section 13.3 of {{QUIC-TRANSPORT}),
 as the receiver will ignore duplicate or out-of-order ACK_FREQUENCY frames
 based on the Sequence Number.
 
-An endpoint MAY send multiple ACK_FREQUENCY frames with different values within a
+An endpoint can send multiple ACK_FREQUENCY frames with different values within a
 connection. A sending endpoint MUST send monotonically increasing values in the
 Sequence Number field, since this field allows ACK_FREQUENCY frames to be processed
 out of order. A receiving endpoint MUST ignore a received ACK_FREQUENCY frame if the

--- a/draft-ietf-quic-ack-frequency.md
+++ b/draft-ietf-quic-ack-frequency.md
@@ -260,26 +260,11 @@ have different values in all fields. An endpoint MUST use a sequence number of 0
 for the first ACK_FREQUENCY frame it constructs and sends, and a strictly
 increasing value thereafter.
 
-An endpoint MUST allow reordered ACK_FREQUENCY frames to be received and
-processed, see {{Section 13.3 of QUIC-TRANSPORT}}.
-
-On the first received ACK_FREQUENCY frame in a connection, an endpoint MUST
-immediately record all values from the frame. The sequence number of the frame
-is recorded as the largest seen sequence number. The new Ack-Eliciting Threshold
-and Request Max Ack Delay values MUST be immediately used for delaying
-acknowledgements; see {{sending}}.
-
-On a subsequently received ACK_FREQUENCY frame, the endpoint MUST check if this
-frame is more recent than any previous ones, as follows:
-
-- If the frame's sequence number is not greater than the largest one seen so
-  far, the endpoint MUST ignore this frame.
-
-- If the frame's sequence number is greater than the largest one seen so far,
-  the endpoint MUST immediately replace old recorded state with values received
-  in this frame. The endpoint MUST start using the new values immediately for
-  delaying acknowledgements; see {{sending}}. The endpoint MUST also replace the
-  recorded sequence number.
+An endpoint might receive an ACK_FREQUENCY frame out of order 
+(see {{Section 13.3 of QUIC-TRANSPORT}}). 
+The enpoint MUST ignore the frame if the Sequence Number is smaller than the last processed Sequence Number.
+Otherwise, the endpoint MUST update its state with values received
+in this frame, including the processed largest Sequence Number.
 
 
 # IMMEDIATE_ACK Frame {#immediate-ack-frame}

--- a/draft-ietf-quic-ack-frequency.md
+++ b/draft-ietf-quic-ack-frequency.md
@@ -245,7 +245,7 @@ based on the Sequence Number.
 
 An endpoint MAY send multiple ACK_FREQUENCY frames with different values within a
 connection. A sending endpoint MUST send monotonically increasing values in the
-Sequence Number field, since this field allows ACK_FREQUENCY frames to be received
+Sequence Number field, since this field allows ACK_FREQUENCY frames to be processed
 out of order. A receiving endpoint MUST ignore a received ACK_FREQUENCY frame if the
 Sequence Number value in the frame is not greater than the largest processed thus far.
 

--- a/draft-ietf-quic-ack-frequency.md
+++ b/draft-ietf-quic-ack-frequency.md
@@ -260,8 +260,8 @@ have different values in all fields. An endpoint MUST use a sequence number of 0
 for the first ACK_FREQUENCY frame it constructs and sends, and a strictly
 increasing value thereafter.
 
-An endpoint might receive an ACK_FREQUENCY frame out of order 
-(see {{Section 13.3 of QUIC-TRANSPORT}}). 
+An endpoint might receive an ACK_FREQUENCY frame out of order
+(see {{Section 13.3 of QUIC-TRANSPORT}}).
 The endpoint MUST ignore the frame if the Sequence Number is smaller than the last processed Sequence Number.
 Otherwise, the endpoint MUST update its state with values received
 in this frame, including the processed largest Sequence Number.


### PR DESCRIPTION
This PR makes the text shorter and tightens the normative requirements around handling of multple ACK_FREQUENCY frames. This PR makes one normative change: Sequence Number value is no longer required to start at zero.