### PR TITLE
Rewrite 'Response to Out-of-Order Packets'

### DIFF
--- a/draft-ietf-quic-ack-frequency.md
+++ b/draft-ietf-quic-ack-frequency.md
@@ -341,13 +341,13 @@ Threshold value SHOULD send an immediate ACK when the gap
 between the smallest Unreported Missing packet and the Largest Unacked is greater
 than or equal to the Reordering Threshold value.
 
-In order to ensure timely loss detection, it is optimal to send a Reordering Threshold value of 1 less than
-the packet threshold used by the data sender for loss detection.
-If the threshold is smaller, the additional ACK does not provide input to
-the loss detection. If the value is larger, it creates unnecessary delays.
-({{Section 18.2 of QUIC-RECOVERY}}) recommends a default packet threshold for
-loss detection of 3, equivalent to a Reordering Threshold of 2.
-
+In order to ensure timely loss detection, it is optimal to send a Reordering
+Threshold value of 1 less than the packet threshold used by the data sender for
+loss detection. If the threshold is smaller, an ACK_FRAME is sent before the
+packet can be declared lost based on the packet threshold. If the value is
+larger, it causes unnecessary delays. ({{Section 18.2 of QUIC-RECOVERY}})
+recommends a default packet threshold for loss detection of 3, equivalent to
+a Reordering Threshold of 2.
 
 If the most recent ACK_FREQUENCY frame received from the peer has a `Reordering
 Threshold` value of 0, the endpoint SHOULD NOT send an immediate

--- a/draft-ietf-quic-ack-frequency.md
+++ b/draft-ietf-quic-ack-frequency.md
@@ -327,7 +327,7 @@ packet. This extension modifies that behavior when an ACK_FREQUENCY frame with
 a Reordering Threshold value other than 1 is received.
 
 Largest Unacked
-: The largest packet number of a received ack-eliciting packet.
+: The largest packet number among all received ack-eliciting packets so far.
 
 Largest Acked
 : The Largest Acknowledged value sent in an ACK frame.

--- a/draft-ietf-quic-ack-frequency.md
+++ b/draft-ietf-quic-ack-frequency.md
@@ -358,7 +358,7 @@ for sending acknowledgements.
 ### Examples
 
 When the reordering threshold is 1, any time a packet is received
-and there is a missing packet, it must be at least 1 packet number less, so
+and there is a missing packet,
 an immediate ACK is sent.
 
 If the reordering theshold is 3 and ACKs are only sent due to reordering:

--- a/draft-ietf-quic-ack-frequency.md
+++ b/draft-ietf-quic-ack-frequency.md
@@ -368,8 +368,8 @@ reordering:
   Receive 8
   Receive 9 -> Send ACK
 
-If the reordering threshold is 5 and we're only considering ACKs sent due to
-reordering:
+If the reordering threshold is 5 and assuming that packets are received close enough
+in time to not exceed max_ack_delay:
 
   Receive 1
   Receive 3 -> 2 Missing

--- a/draft-ietf-quic-ack-frequency.md
+++ b/draft-ietf-quic-ack-frequency.md
@@ -341,11 +341,13 @@ Threshold value SHOULD send an immediate ACK when the gap
 between the smallest Unreported Missing packet and the Largest Unacked is greater
 than or equal to the Reordering Threshold value.
 
-In order to ensure timely loss detection and avoid unnecessary immediate
-acknowledgements, it is optimal to send a Reordering Threshold value of 1 less than
+In order to ensure timely loss detection, it is optimal to send a Reordering Threshold value of 1 less than
 the packet threshold used by the data sender for loss detection.
+If the threshold is smaller, the additional ACK does not provide input to
+the loss detection. If the value is larger, it creates unnecessary delays.
 ({{Section 18.2 of QUIC-RECOVERY}}) recommends a default packet threshold for
 loss detection of 3, equivalent to a Reordering Threshold of 2.
+
 
 If the most recent ACK_FREQUENCY frame received from the peer has a `Reordering
 Threshold` value of 0, the endpoint SHOULD NOT send an immediate

--- a/draft-ietf-quic-ack-frequency.md
+++ b/draft-ietf-quic-ack-frequency.md
@@ -323,7 +323,7 @@ strategy.
 
 As specified in {{Section 13.2.1 of QUIC-TRANSPORT}}, endpoints are expected to
 send an acknowledgement immediately on receiving a reordered ack-eliciting
-packet. This extension modifies that behavior when an ACK FREQUENCY frame with
+packet. This extension modifies that behavior when an ACK_FREQUENCY frame with
 a Reordering Threshold value other than 1 is received.
 
 Largest Unacked

--- a/draft-ietf-quic-ack-frequency.md
+++ b/draft-ietf-quic-ack-frequency.md
@@ -358,8 +358,7 @@ for sending acknowledgements.
 ### Examples
 
 When the reordering threshold is 1, any time a packet is received
-and there is a missing packet,
-an immediate ACK is sent.
+and there is a missing packet, an immediate ACK is sent.
 
 If the reordering theshold is 3 and ACKs are only sent due to reordering:
 

--- a/draft-ietf-quic-ack-frequency.md
+++ b/draft-ietf-quic-ack-frequency.md
@@ -336,8 +336,8 @@ Unreported Missing
 : Packets with packet numbers between the Largest Unacked and Largest Acked that
   have not yet been received.
 
-An endpoint that receives an ACK_FREQUENCY frame with a Reordering
-Threshold value other than 0x00 SHOULD send an immediate ACK when the gap
+An endpoint that receives an ACK_FREQUENCY frame with a non-zero Reordering
+Threshold value SHOULD send an immediate ACK when the gap
 between the smallest Unreported Missing packet and the Largest Unacked is greater
 than or equal to the Reordering Threshold value.
 
@@ -347,7 +347,7 @@ used by the data sender for loss detection. ({{Section 18.2 of QUIC-RECOVERY}})
 recommends a default packet threshold for loss detection of 3.
 
 If the most recent ACK_FREQUENCY frame received from the peer has a `Reordering
-Threshold` value of 0x00, the endpoint SHOULD NOT send an immediate
+Threshold` value of 0, the endpoint SHOULD NOT send an immediate
 acknowledgement in response to packets received out of order, and instead
 rely on the peer's `Ack-Eliciting Threshold` and `max_ack_delay` thresholds
 for sending acknowledgements.

--- a/draft-ietf-quic-ack-frequency.md
+++ b/draft-ietf-quic-ack-frequency.md
@@ -341,10 +341,11 @@ Threshold value SHOULD send an immediate ACK when the gap
 between the smallest Unreported Missing packet and the Largest Unacked is greater
 than or equal to the Reordering Threshold value.
 
-In order to ensure timely loss detection, the Reordering Threshold provided
-in the ACK_FREQUENCY frame SHOULD NOT be larger than the re-ordering threshold
-used by the data sender for loss detection. ({{Section 18.2 of QUIC-RECOVERY}})
-recommends a default packet threshold for loss detection of 3.
+In order to ensure timely loss detection and avoid unnecessary immediate
+acknowledgements, it is optimal to send a Reordering Threshold value of 1 less than
+the packet threshold used by the data sender for loss detection.
+({{Section 18.2 of QUIC-RECOVERY}}) recommends a default packet threshold for
+loss detection of 3, equivalent to a Reordering Threshold of 2.
 
 If the most recent ACK_FREQUENCY frame received from the peer has a `Reordering
 Threshold` value of 0, the endpoint SHOULD NOT send an immediate

--- a/draft-ietf-quic-ack-frequency.md
+++ b/draft-ietf-quic-ack-frequency.md
@@ -368,6 +368,16 @@ reordering:
   Receive 8
   Receive 9 -> Send ACK
 
+If the reordering threshold is 5 and we're only considering ACKs sent due to
+reordering:
+
+  Receive 1
+  Receive 3
+  Receive 5
+  Receive 6
+  Receive 7 -> Send ACK
+  Receive 8
+  Receive 9 -> Send ACK
 
 ## Expediting Congestion Signals {#congestion}
 

--- a/draft-ietf-quic-ack-frequency.md
+++ b/draft-ietf-quic-ack-frequency.md
@@ -358,8 +358,8 @@ When the reordering threshold is 1, any time a packet is received
 and there is a missing packet, it must be at least 1 packet number less, so
 an immediate ACK is sent.
 
-If the reordering theshold is 3 and we're only considering ACKs sent due to
-reordering:
+If the reordering theshold is 3 and assuming that packets are received close enough
+in time to not exceed max_ack_delay:
 
   Receive 1
   Receive 3 -> 2 Missing

--- a/draft-ietf-quic-ack-frequency.md
+++ b/draft-ietf-quic-ack-frequency.md
@@ -323,24 +323,51 @@ strategy.
 
 As specified in {{Section 13.2.1 of QUIC-TRANSPORT}}, endpoints are expected to
 send an acknowledgement immediately on receiving a reordered ack-eliciting
-packet. This extension modifies this behavior.
+packet. This extension modifies that behavior when an ACK FREQUENCY frame with
+a Reordering Threshold value other than 1 is received.
+
+Largest Unacked
+: The largest packet number of a received ack-eliciting packet.
+
+Largest Acked
+: The Largest Acknowledged value sent in in an ACK frame.
+
+Unreported Missing
+: Packets with packet numbers between the Largest Unacked and Largest Acked that
+  have not yet been received.
+
+An endpoint that receives an ACK_FREQUENCY frame with a Reordering
+Threshold value other than 0x00 SHOULD send an immediate ACK when the gap
+between the smallest Unreported Missing packet and the Largest Unacked is greater
+than or equal to the Reordering Threshold value.
 
 In order to ensure timely loss detection, the Reordering Threshold provided
 in the ACK_FREQUENCY frame SHOULD NOT be larger than the re-ordering threshold
 used by the data sender for loss detection. ({{Section 18.2 of QUIC-RECOVERY}})
 recommends a default packet threshold for loss detection of 3.
 
-An endpoint, that receives an ACK_FREQUENCY frame with a Reordering
-Threshold value other than 0x00, SHOULD immediately send an ACK frame
-when the packet number of largest unacknowledged packet since
-the last detected reordering event exceeds the Reordering Threshold.
-
 If the most recent ACK_FREQUENCY frame received from the peer has a `Reordering
-Threshold` value of 0x00, the endpoint does not make this exception. That
-is, the endpoint SHOULD NOT send an immediate acknowledgement in response to
-packets received out of order, and instead continues to use the peer's
-`Ack-Eliciting Threshold` and `max_ack_delay` thresholds for sending
-acknowledgements.
+Threshold` value of 0x00, the endpoint SHOULD NOT send an immediate
+acknowledgement in response to packets received out of order, and instead
+rely on the peer's `Ack-Eliciting Threshold` and `max_ack_delay` thresholds
+for sending acknowledgements.
+
+### Examples
+
+When the reordering threshold is 1, any time a packet is received
+and there is a missing packet, it must be at least 1 packet number less, so
+an immediate ACK is sent.
+
+If the reordering theshold is 3 and we're only considering ACKs sent due to
+reordering:
+
+  Receive 1
+  Receive 3
+  Receive 4
+  Receive 5 -> Send ACK
+  Receive 8
+  Receive 9 -> Send ACK
+
 
 ## Expediting Congestion Signals {#congestion}
 

--- a/draft-ietf-quic-ack-frequency.md
+++ b/draft-ietf-quic-ack-frequency.md
@@ -362,20 +362,21 @@ If the reordering theshold is 3 and ACKs are only sent due to reordering:
 
   Receive 1
   Receive 3 -> 2 Missing
-  Receive 4
-  Receive 5 -> Send ACK
-  Receive 8
-  Receive 9 -> Send ACK
+  Receive 4 -> 2 Missing
+  Receive 5 -> Send ACK because of 2
+  Receive 8 -> 6,7 Missing
+  Receive 9 -> Send ACK because of 6, 7 Missing
+  Receive 10 -> Send ACK because of 7
 
 If the reordering threshold is 5 and ACKs are only sent due to reordering:
 
   Receive 1
   Receive 3 -> 2 Missing
-  Receive 5 -> 4 Missing
-  Receive 6
-  Receive 7 -> Send ACK
-  Receive 8
-  Receive 9 -> Send ACK
+  Receive 5 -> 2 Missing, 4 Missing
+  Receive 6 -> 2 Missing, 4 Missing
+  Receive 7 -> Send ACK because of 2, 4 Missing
+  Receive 8 -> 4 Missing
+  Receive 9 -> Send ACK because of 4
 
 ## Expediting Congestion Signals {#congestion}
 

--- a/draft-ietf-quic-ack-frequency.md
+++ b/draft-ietf-quic-ack-frequency.md
@@ -330,7 +330,7 @@ Largest Unacked
 : The largest packet number of a received ack-eliciting packet.
 
 Largest Acked
-: The Largest Acknowledged value sent in in an ACK frame.
+: The Largest Acknowledged value sent in an ACK frame.
 
 Unreported Missing
 : Packets with packet numbers between the Largest Unacked and Largest Acked that

--- a/draft-ietf-quic-ack-frequency.md
+++ b/draft-ietf-quic-ack-frequency.md
@@ -358,8 +358,7 @@ When the reordering threshold is 1, any time a packet is received
 and there is a missing packet, it must be at least 1 packet number less, so
 an immediate ACK is sent.
 
-If the reordering theshold is 3 and assuming that packets are received close enough
-in time to not exceed max_ack_delay:
+If the reordering theshold is 3 and ACKs are only sent due to reordering:
 
   Receive 1
   Receive 3 -> 2 Missing
@@ -368,8 +367,7 @@ in time to not exceed max_ack_delay:
   Receive 8
   Receive 9 -> Send ACK
 
-If the reordering threshold is 5 and assuming that packets are received close enough
-in time to not exceed max_ack_delay:
+If the reordering threshold is 5 and ACKs are only sent due to reordering:
 
   Receive 1
   Receive 3 -> 2 Missing

--- a/draft-ietf-quic-ack-frequency.md
+++ b/draft-ietf-quic-ack-frequency.md
@@ -362,7 +362,7 @@ If the reordering theshold is 3 and we're only considering ACKs sent due to
 reordering:
 
   Receive 1
-  Receive 3
+  Receive 3 -> 2 Missing
   Receive 4
   Receive 5 -> Send ACK
   Receive 8
@@ -372,8 +372,8 @@ If the reordering threshold is 5 and we're only considering ACKs sent due to
 reordering:
 
   Receive 1
-  Receive 3
-  Receive 5
+  Receive 3 -> 2 Missing
+  Receive 5 -> 4 Missing
   Receive 6
   Receive 7 -> Send ACK
   Receive 8

--- a/draft-ietf-quic-ack-frequency.md
+++ b/draft-ietf-quic-ack-frequency.md
@@ -327,7 +327,7 @@ packet. This extension modifies that behavior when an ACK_FREQUENCY frame with
 a Reordering Threshold value other than 1 is received.
 
 Largest Unacked
-: The largest packet number among all received ack-eliciting packets so far.
+: The largest packet number among all received ack-eliciting packets.
 
 Largest Acked
 : The Largest Acknowledged value sent in an ACK frame.


### PR DESCRIPTION
Fixes #140 and provides two simple examples

Written as an alternative to #143