### PR TITLE
Required behaviour after migration

### DIFF
--- a/draft-ietf-quic-ack-frequency.md
+++ b/draft-ietf-quic-ack-frequency.md
@@ -520,11 +520,11 @@ frame ({{Section 9.2 of QUIC-TRANSPORT}}) it sends or it can send only an
 IMMEDIATE_ACK frame, which is a non-probing frame.
 
 An endpoint's congestion controller and RTT estimator are reset upon
-confirmation of migration ({{Section 9.4 of QUIC-TRANSPORT}}), which can impact
-the number of acknowledgements received after migration. An endpoint that has
-sent an ACK_FREQUENCY frame earlier in the connection SHOULD update and send a
-new ACK_FREQUENCY frame immediately upon confirmation of connection migration.
-
+confirmation of migration (Section 9.4 of [QUIC-TRANSPORT]), this
+restores the default delay of acknowledgements.
+Therefore, an endpoint that has sent an ACK_FREQUENCY frame earlier in the
+connection ought to send a new ACK_FREQUENCY frame upon confirmation of 
+connection migration if it wishes to restore an updated delay for acknowledgements.
 
 # Security Considerations
 


### PR DESCRIPTION
This is in response to #189, which says that an endpoint ought to restore the state for a new path, rather than an RFC2119 recommendation, motivated because the decision to restore depends on whether the path is actually the same.