### PR TITLE
Update draft-ietf-quic-ack-frequency.md

### DIFF
--- a/draft-ietf-quic-ack-frequency.md
+++ b/draft-ietf-quic-ack-frequency.md
@@ -509,7 +509,7 @@ delayed or unnecessary packet transmissions.
 
 A sender might use timers to detect loss of PMTU probe packets
 ({{Section 14 of QUIC-TRANSPORT}}). A sender SHOULD
-bundle an IMMEDIATE_ACK frame with any PMTU probes to avoid triggering such
+bundle a PING frame or an IMMEDIATE_ACK frame with any PMTU probes to avoid triggering such
 timers.
 
 ## Connection Migration {#migration}


### PR DESCRIPTION
DPLPMTUD would sometimes use ping frames. So, if I understand,  a method using PING frames does not need the immediate ACK function, either one or the other is sufficient.