### PR TITLE
Send an immediate ACK when loss can be detected

### DIFF
--- a/draft-ietf-quic-ack-frequency.md
+++ b/draft-ietf-quic-ack-frequency.md
@@ -353,9 +353,13 @@ Largest Unacked:
 Largest Acked:
 : The Largest Acknowledged value sent in an ACK frame.
 
+Largest Reported:
+: The largest packet number that could be declared lost with the specified
+  Reordering Threshold, which is Largest Acked - Reordering Threshold + 1.
+
 Unreported Missing:
-: Packets with packet numbers between the Largest Unacked and Largest Acked that
-  have not yet been received.
+: Packets with packet numbers between the Largest Unacked and Largest Reported
+  that have not yet been received.
 
 An endpoint that receives an ACK_FREQUENCY frame with a non-zero Reordering
 Threshold value SHOULD send an immediate ACK when the gap


### PR DESCRIPTION
Given the specified Reordering Threshold.

This is possible either when the delayed ACK timer or the Ack-Eliciting Threshold causes an ACK to be sent before the packet can be declared immediately lost, but with a higher Largest Acked than the missing packet.

Fixes #213
Closes #219 