### PR TITLE
SHOULD set max_ack_delay and FRAME_ENCODING_ERROR

### DIFF
--- a/draft-ietf-quic-ack-frequency.md
+++ b/draft-ietf-quic-ack-frequency.md
@@ -261,11 +261,12 @@ Requested Max Ack Delay:
   requests the peer update its max_ack_delay
   ({{Section 18.2 of QUIC-TRANSPORT}}). The value of this field is in
   microseconds, unlike the max_ack_delay transport parameter, which is in
-  milliseconds. Sending a value smaller than the min_ack_delay advertised
-  by the peer is invalid. Receipt of an invalid value MUST be treated as a
-  connection error of type TRANSPORT_PARAMETER_ERROR. On receiving a valid value in
-  this field, the endpoint MUST update its max_ack_delay to the value provided
-  by the peer. Note that values of 2^14 or greater are invalid for max_ack_delay.
+  milliseconds. On receipt of a valid value, the endpoint SHOULD update
+  its max_ack_delay to the value provided by the peer. Note that values
+  of 2^14 or greater are invalid for max_ack_delay. Sending a value smaller
+  than the min_ack_delay advertised by the peer is invalid. Receipt of an
+  invalid value MUST be treated as a connection error of type
+  FRAME_ENCODING_ERROR. 
 
 Reordering Threshold:
 


### PR DESCRIPTION
fixes #232

This PR changes a "MUST set the max_ack_delay" to a SHOULD. In the whole draft, we now rather say that the ACK_FREQUENCY frame is a request. We can't enforce a certain ACK sending behaviour and as such, I think this should also only be a SHOULD.

Further it change the error type to FRAME_ENCODING_ERROR. This is an encoding error during frame process and inline with e.g. https://www.rfc-editor.org/rfc/rfc9000#section-4.6-2 on MAX_STREAMS frame this should therefore be a FRAME_ENCODING_ERROR.

And finally this PR changes the order of sentences, to make it more clear that both a too low and a too high value can be invalid.