### PR TITLE
Tweak Negotiating Extension Use

### DIFF
--- a/draft-ietf-quic-ack-frequency.md
+++ b/draft-ietf-quic-ack-frequency.md
@@ -177,22 +177,23 @@ extension provides a mechanism to solve this problem.
 
 # Negotiating Extension Use {#nego}
 
-After the successful negotiation of this extension two new frames can be used
-to provide guidance about delaying and sending of ACK frames to its peer. These
-frames are the ACK_FREQUENCY frame (see {{ack-frequency-frame}}) and the
-IMMEDIATE_ACK frame (see {{immediate-ack-frame}}).
+After a data receiver advertises support for this extension, two new frames
+can be sent by the data sender to provide guidance about delaying and sending
+ACK frames. These frames are the ACK_FREQUENCY frame
+(see {{ack-frequency-frame}}) and the IMMEDIATE_ACK frame
+(see {{immediate-ack-frame}}).
 
 Endpoints advertise their support of the extension described in this document by
 sending the following transport parameter ({{Section 7.2 of QUIC-TRANSPORT}}):
 
 min_ack_delay (0xff04de1b):
 
-: A variable-length integer representing the minimum amount of time in
-  microseconds by which the endpoint that is sending this value is able to
-  delay an acknowledgment. This limit could be based on the receiver's clock
-  or timer granularity. min_ack_delay is used by the peer to avoid requesting
-  too small a value in the Requested Max Ack Delay field of the ACK_FREQUENCY
-  frame.
+: A variable-length integer representing the minimum amount of time, in
+  microseconds, that the endpoint sending this value is willing to
+  delay an acknowledgment. This limit could be based on the data receiver's
+  clock or timer granularity. min_ack_delay is used by the data sender to
+  avoid requesting too small a value in the Requested Max Ack Delay field of the
+  ACK_FREQUENCY frame.
 
 An endpoint's min_ack_delay MUST NOT be greater than its max_ack_delay.
 Endpoints that support this extension MUST treat receipt of a min_ack_delay that


### PR DESCRIPTION
Possibly we should rename this to "Advertising Extension Support" or something similar as well, since I'm not sure I'd consider this unilateral advertisement approach 'negotiating'?