### PR TITLE
Re-add sentence that IMMEDIATE_ACK does not need to be retransmitted.

### DIFF
--- a/draft-ietf-quic-ack-frequency.md
+++ b/draft-ietf-quic-ack-frequency.md
@@ -315,6 +315,8 @@ IMMEDIATE_ACK Frame {
 }
 ~~~
 
+IMMEDIATE_ACK frames do not need to be retransmitted.
+
 # Sending Acknowledgments {#sending}
 
 Prior to receiving an ACK_FREQUENCY frame, endpoints send acknowledgments as


### PR DESCRIPTION
fixes issue #310

This was agreed and added in PR #136 but, I believe by mistake, removed in editorial pass in PR #160.