### PR TITLE
Tiniest NiT on CE ?

### DIFF
--- a/draft-ietf-quic-ack-frequency.md
+++ b/draft-ietf-quic-ack-frequency.md
@@ -463,7 +463,7 @@ Threshold or max_ack_delay. Therefore, CE-marking only triggers an immediate
 acknowledgement when there is a transition from non-CE-marked to CE-marked.
 
 If the Ack-Eliciting Threshold is 0, every ack-eliciting packet is immediately
-acknowledged, CE marked or not. If the Ack-Eliciting Threshold
+acknowledged (both when the packet was CE marked and when not). If the Ack-Eliciting Threshold
 is 1, the default behavior as specified in RFC9000 applies, which recommends to
 immediately acknowledge all packets marked with CE (see
 {{Section 13.2.1 of QUIC-TRANSPORT}}).


### PR DESCRIPTION
Immediate response when CE marked or not, ought to refer to the packet being ACK'ed.