### PR TITLE
add unit for clarity

### DIFF
--- a/draft-ietf-quic-ack-frequency.md
+++ b/draft-ietf-quic-ack-frequency.md
@@ -263,7 +263,7 @@ Requested Max Ack Delay:
   microseconds, unlike the max_ack_delay transport parameter, which is in
   milliseconds. On receipt of a valid value, the endpoint SHOULD update
   its max_ack_delay to the value provided by the peer. Note that values
-  of 2^14 or greater are invalid for max_ack_delay, as specified in
+  of 2^14 milliseconds or greater are invalid for max_ack_delay, as specified in
   {{Section 18.2 of QUIC-TRANSPORT}}. A value smaller than the min_ack_delay
   advertised by the peer is also invalid. Receipt of an invalid value MUST be
   treated as a connection error of type PROTOCOL_VIOLATION.


### PR DESCRIPTION
Adding milliseconds here makes it clear that the values above 2^14 _milliseconds_ are invalid. The distinction helps because the field is in microseconds, but the limit and reference are in milliseconds.